### PR TITLE
Ignore Stack Sizes of 1

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -17,6 +17,9 @@ local ignora_by_name = {
 }
 
 local function is_stackable(item)
+	if settings.startup["Noxys_StackSizeMultiplier-ignoreonestacks"].value then
+		if item.stack_size and item.stack_size == 1 then return false end
+	end
 	if not item.flags then return true end
 	if type(item.flags) ~= "table" then return true end
 	for _,v in pairs(item.flags) do

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "Noxys_StackSizeMultiplier",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"factorio_version": "1.1",
 	"title": "Noxys Stack Size Multiplier",
 	"author": "Noxy",

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -2,7 +2,7 @@
 Noxys_StackSizeMultiplier-multiplier=Stack size multiplier
 Noxys_StackSizeMultiplier-tweakbots=Tweak construction robots
 Noxys_StackSizeMultiplier-tweaklogibots=Tweak logistics robots
-Noxys_StackSizeMultiplier-ignoreonestacks=Ignore Stacks of One
+Noxys_StackSizeMultiplier-ignoreonestacks=Ignore stacks of one
 
 [mod-setting-description]
 Noxys_StackSizeMultiplier-multiplier=The Multiplier. You can use decimal values below 1 to reduce the stack sizes (Actual stacks sizes will always be at least 1 item).

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -2,8 +2,10 @@
 Noxys_StackSizeMultiplier-multiplier=Stack size multiplier
 Noxys_StackSizeMultiplier-tweakbots=Tweak construction robots
 Noxys_StackSizeMultiplier-tweaklogibots=Tweak logistics robots
+Noxys_StackSizeMultiplier-ignoreonestacks=Ignore Stacks of One
 
 [mod-setting-description]
 Noxys_StackSizeMultiplier-multiplier=The Multiplier. You can use decimal values below 1 to reduce the stack sizes (Actual stacks sizes will always be at least 1 item).
 Noxys_StackSizeMultiplier-tweakbots=Tweak construction robots to have the same multiplier applied to their payload capacity.
 Noxys_StackSizeMultiplier-tweaklogibots=Tweak logistics robots to have the same multiplier applied to their payload capacity.
+Noxys_StackSizeMultiplier-ignoreonestacks=Prevent items that would otherwise have a stack size of one, such as satellites and buildings, from being multiplied. (Intended to prevent automatic launching of more than 1 satellite at a time).

--- a/settings.lua
+++ b/settings.lua
@@ -23,6 +23,13 @@ data:extend({
 		default_value = false,
 		order = "b",
 	},
+	{
+		type = "bool-setting",
+		name = "Noxys_StackSizeMultiplier-ignoreonestacks",
+		setting_type = "startup",
+		default_value = false,
+		order = "c",
+	},
 	-- Global
 
 	-- Per user


### PR DESCRIPTION
As mentioned in this [discussion post](https://mods.factorio.com/mod/Noxys_StackSizeMultiplier/discussion/62bfb7bd53ca6e87a2d66fdd), these are the changes I implemented to ignore stack sizes of one.

I added an attempt at a null check before checking the stack size (Not sure if necessary or enough to catch all possible issues), as well as actual settings and locale for it. Though, at current I only made locale for EN. Setting is off by default.